### PR TITLE
Push the value of dark prop to the back-end

### DIFF
--- a/share/jupyter/nbconvert/templates/vuetify-base/util.js
+++ b/share/jupyter/nbconvert/templates/vuetify-base/util.js
@@ -193,6 +193,7 @@ window.init = async (voila) => {
             const model = await modelPromise;
             if (model.name === 'ThemeModel' && themeIsdark !== undefined) {
                 model.set('dark', themeIsdark);
+                model.save_changes();
                 app.$vuetify = original;
             }
             const meta = model.get('_metadata');


### PR DESCRIPTION
Push the value of `dark` prop to the back-end so that the Theme model is up to date. This allows a widget to properly switch the theme by switching `v.theme.dark` in python (`v` being the ipyvuetify instance).