### PR TITLE
fix: wrong boxing model set for Vuetify

### DIFF
--- a/share/jupyter/nbconvert/templates/vuetify-base/index.html.j2
+++ b/share/jupyter/nbconvert/templates/vuetify-base/index.html.j2
@@ -19,6 +19,11 @@
 
         {% set nb_title = nb.metadata.get('title', '') or resources['metadata']['name'] %}
 		<title>Voila: {{nb_title}}</title>
+		<style>
+		    .v-application * {
+		        box-sizing: border-box;
+		    }
+		</style>
     </head>
 
     <body data-base-url="{{resources.base_url}}voila/">


### PR DESCRIPTION
Fixes #51 and #ipyvuetify/200

Removing the blueprint reset styles doesn't work in newer versions
of Voila, which causes the wrong boxing model to be used.